### PR TITLE
Fixed cast error as AutidDetail not always can be cast to AttributeAu…

### DIFF
--- a/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/PluginControl.cs
+++ b/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/PluginControl.cs
@@ -174,6 +174,7 @@ namespace BDK.XrmToolBox.RecycleBin
                             RetrieveAuditDetailsRequest auditDetailRequest = new RetrieveAuditDetailsRequest();
                             auditDetailRequest.AuditId = item.Id;
                             RetrieveAuditDetailsResponse response = (RetrieveAuditDetailsResponse)Service.Execute(auditDetailRequest);
+                            if (!(response.AuditDetail is AttributeAuditDetail)) continue; 
                             AttributeAuditDetail attributeDetail = (AttributeAuditDetail)response.AuditDetail;
                             EntityMetadata metadata = entityMetadataList.FirstOrDefault(x => (x.ObjectTypeCode == selectedEntity.Item1));
                             AuditItem auditItem = new Model.AuditItem()


### PR DESCRIPTION
Added check if correct type: 
    if (!(response.AuditDetail is AttributeAuditDetail)) continue; 
Before casting:
   AttributeAuditDetail attributeDetail = (AttributeAuditDetail)response.AuditDetail;
As AuditDetail can be of:
    Microsoft.Crm.Sdk.Messages.AttributeAuditDetail
    Microsoft.Crm.Sdk.Messages.RelationshipAuditDetail
    Microsoft.Crm.Sdk.Messages.RolePrivilegeAuditDetail
    Microsoft.Crm.Sdk.Messages.ShareAuditDetail
    Microsoft.Crm.Sdk.Messages.UserAccessAuditDetail