### PR TITLE
FetchXML Condition Between not working. Changed to greater than and less than

### DIFF
--- a/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/BDK.XrmToolBox.RecycleBin.csproj
+++ b/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/BDK.XrmToolBox.RecycleBin.csproj
@@ -193,6 +193,7 @@
     <EmbeddedResource Include="FetchXml.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>FetchXml.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PluginControl.resx">
       <DependentUpon>PluginControl.cs</DependentUpon>

--- a/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/FetchXml.Designer.cs
+++ b/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/FetchXml.Designer.cs
@@ -19,7 +19,7 @@ namespace BDK.XrmToolBox.RecycleBin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class FetchXml {
@@ -72,9 +72,8 @@ namespace BDK.XrmToolBox.RecycleBin {
         ///    &lt;attribute name=&quot;auditid&quot; /&gt;
         ///    &lt;filter type=&quot;and&quot; &gt;
         ///      &lt;condition attribute=&quot;operation&quot; operator=&quot;eq&quot; value=&quot;3&quot; /&gt;
-        ///      &lt;condition attribute=&quot;createdon&quot; operator=&quot;between&quot; &gt;
-        ///        &lt;value&gt;{0}&lt;/value&gt;
-        ///        &lt;value&gt;{1}&lt;/ [rest of string was truncated]&quot;;.
+        ///      &lt;condition attribute=&quot;createdon&quot; operator=&quot;ge&quot; value=&quot;{0}&quot; /&gt;
+        ///      &lt;condition attribute=&quot;createdon&quot; o [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DeleteAuditLogsByUser {
             get {

--- a/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/FetchXml.resx
+++ b/BDK.XrmToolBox/BDK.XrmToolBox.RecycleBin/FetchXml.resx
@@ -129,10 +129,8 @@
     &lt;attribute name="auditid" /&gt;
     &lt;filter type="and" &gt;
       &lt;condition attribute="operation" operator="eq" value="3" /&gt;
-      &lt;condition attribute="createdon" operator="between" &gt;
-        &lt;value&gt;{0}&lt;/value&gt;
-        &lt;value&gt;{1}&lt;/value&gt;
-      &lt;/condition&gt;
+      &lt;condition attribute="createdon" operator="ge" value="{0}" /&gt;
+      &lt;condition attribute="createdon" operator="lt" value="{1}" /&gt;
       &lt;condition attribute="objecttypecode" operator="eq" value="{2}" /&gt;
       &lt;condition attribute="userid" operator="eq" value="{3}" /&gt;
     &lt;/filter&gt;
@@ -155,10 +153,8 @@
     &lt;attribute name="objectidname" /&gt;
     &lt;filter type="and" &gt;
       &lt;condition attribute="operation" operator="eq" value="3" /&gt;
-      &lt;condition attribute="createdon" operator="between" &gt;
-        &lt;value&gt;{0}&lt;/value&gt;
-        &lt;value&gt;{1}&lt;/value&gt;
-      &lt;/condition&gt;
+      &lt;condition attribute="createdon" operator="ge" value="{0}" /&gt;
+      &lt;condition attribute="createdon" operator="lt" value="{1}" /&gt;
       &lt;condition attribute="objecttypecode" operator="eq" value="{2}" /&gt;
     &lt;/filter&gt;
   &lt;/entity&gt;


### PR DESCRIPTION
Hi Depak,

I've noticed that the date filtering in retrieving deleted records didn't work and it was due to FetchXML condition between not workring.
I have change code to use greater than and less than instead and it seems to work now.

Regards,
Henrik